### PR TITLE
 Follow the ILD_l4_v02 calorimeter collections update to fix the ILD …

### DIFF
--- a/ced2go/ced2go-template-DD4.xml
+++ b/ced2go/ced2go-template-DD4.xml
@@ -127,6 +127,13 @@
      HcalBarrelRegCollection     0 3 2
      HcalEndCapRingsCollection   0 3 2
 
+     LHCalCollection             0 3 2
+     EcalBarrelCollection        0 3 2
+     EcalEndcapCollection        0 3 2
+     EcalEndcapRingCollection    0 3 2
+     HcalEndcapsCollection       0 3 2
+     HcalEndcapRingCollection    0 3 2
+
      ECalBarrelCollection 0 3 2
      ECalEndcapCollection 0 3 2
      ECalPlugCollection 0 3 2
@@ -135,7 +142,6 @@
      HCalRingCollection 0 3 2
      YokeBarrelCollection 0 3 2
      YokeEndcapCollection 0 3 2
-     LumiCalCollection 0 3 2
      BeamCalCollection 0 3 2
 
 


### PR DESCRIPTION
…calorimeter collections name in ced2go template.



BEGINRELEASENOTES
-   Follow the ILD_l4_v02 calorimeter collections update to fix the ILD calorimeter collections name in ced2go template.
    - remove the PreShower collections, there is no any PreShower collection in ILD_l4_v02.
    - remove unused Muon collections, Yoke collections are used and are already existed.
    - remove duplicated  LumiCalCollection.
    - follow the Ecal and Hcal collections name udpate in ILD_l4_v02.

ENDRELEASENOTES