### PR TITLE
Show evtnum

### DIFF
--- a/ced2go/ced2go-template-DD4.xml
+++ b/ced2go/ced2go-template-DD4.xml
@@ -113,7 +113,6 @@
      OTrackerHits          0 5 11
      VXDEndcapTrackerHits  0 5 11
 
-     HcalEndCapsCollection       0 3 2
      LHcalCollection             0 3 2
      LumiCalCollection           0 3 2
      MuonBarrelCollection        0 3 2
@@ -125,25 +124,32 @@
      EcalEndcapSiliconCollection 0 3 2  
      EcalEndcapSiliconPreShower  0 3 2  
      HcalBarrelRegCollection     0 3 2
-     HcalEndCapRingsCollection   0 3 2
-
-     LHCalCollection             0 3 2
-     EcalBarrelCollection        0 3 2
-     EcalEndcapCollection        0 3 2
-     EcalEndcapRingCollection    0 3 2
-     HcalEndcapsCollection       0 3 2
+     HcalEndCapRingCollection    0 3 2
+     HcalEndCapsCollection       0 3 2
      HcalEndcapRingCollection    0 3 2
+     HcalEndcapsCollection       0 3 2
+
+     ECalBarrelSiHitsEven          0 3 2
+     ECalBarrelSiHitsOdd           0 3 2
+     ECalEndcapSiHitsEven          0 3 2
+     ECalEndcapSiHitsOdd           0 3 2
+     EcalBarrelCollection          0 3 2
+     EcalEndcapsCollection         0 3 2
+     YokeEndcapsCollection         0 3 2
 
      ECalBarrelCollection 0 3 2
      ECalEndcapCollection 0 3 2
      ECalPlugCollection 0 3 2
+     EcalBarrelCollection 0 3 2
+     EcalEndcapCollection 0 3 2
+     EcalPlugCollection 0 3 2
      HCalBarrelCollection 0 3 2
      HCalEndcapCollection 0 3 2
      HCalRingCollection 0 3 2
      YokeBarrelCollection 0 3 2
      YokeEndcapCollection 0 3 2
+     LumiCalCollection 0 3 2
      BeamCalCollection 0 3 2
-
 
      HCALEndcap   0 5 12
      HCALOther    0 5 12
@@ -155,6 +161,13 @@
      ECALEndcap   0 2 12
      ECALOther    0 2 12
      HCALBarrel   0 5 12
+     EcalBarrelCollectionRec      0 5 12
+     EcalEndcapRingCollectionRec  0 5 12
+     EcalEndcapsCollectionRec     0 5 12
+     HcalBarrelCollectionRec      0 5 12
+     HcalEndcapRingCollectionRec  0 5 12
+     HcalEndcapsCollectionRec     0 5 12
+
 
      TruthTracks      0 6 3
      ForwardTracks    0 6 4

--- a/ced2go/ced2go-template.xml
+++ b/ced2go/ced2go-template.xml
@@ -25,7 +25,7 @@ $LCIOInputFiles$
   <parameter name="SkipNEvents" value="0" />  
   <parameter name="SupressCheck" value="false" />  
   <parameter name="GearXMLFile"> $GearXMLFile$ </parameter>  
-<parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> DEBUG0 MESSAGE  </parameter>  
+<parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE  </parameter>
   <!-- parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE  </parameter --> 
 
  </global>
@@ -100,7 +100,6 @@ $LCIOInputFiles$
        OTrackerHits          0 5 11
        VXDEndcapTrackerHits  0 5 11
        
-       HcalEndCapsCollection       0 3 2
        LHcalCollection             0 3 2
        LumiCalCollection           0 3 2
        MuonBarrelCollection        0 3 2
@@ -112,7 +111,18 @@ $LCIOInputFiles$
        EcalEndcapSiliconCollection 0 3 2  
        EcalEndcapSiliconPreShower  0 3 2  
        HcalBarrelRegCollection     0 3 2
-       HcalEndCapRingsCollection   0 3 2
+       HcalEndCapRingCollection    0 3 2
+       HcalEndCapsCollection       0 3 2
+       HcalEndcapRingCollection    0 3 2
+       HcalEndcapsCollection       0 3 2
+
+       ECalBarrelSiHitsEven          0 3 2
+       ECalBarrelSiHitsOdd           0 3 2
+       ECalEndcapSiHitsEven          0 3 2
+       ECalEndcapSiHitsOdd           0 3 2
+       EcalBarrelCollection          0 3 2
+       EcalEndcapsCollection         0 3 2
+       YokeEndcapsCollection         0 3 2
 
        ECalBarrelCollection 0 3 2
        ECalEndcapCollection 0 3 2
@@ -128,7 +138,6 @@ $LCIOInputFiles$
        LumiCalCollection 0 3 2
        BeamCalCollection 0 3 2
 
-
        HCALEndcap   0 5 12
        HCALOther    0 5 12
        MUON         0 2 12
@@ -139,6 +148,12 @@ $LCIOInputFiles$
        ECALEndcap   0 2 12
        ECALOther    0 2 12
        HCALBarrel   0 5 12
+       EcalBarrelCollectionRec      0 5 12
+       EcalEndcapRingCollectionRec  0 5 12
+       EcalEndcapsCollectionRec     0 5 12
+       HcalBarrelCollectionRec      0 5 12
+       HcalEndcapRingCollectionRec  0 5 12
+       HcalEndcapsCollectionRec     0 5 12
 
        TruthTracks      0 6 3
        ForwardTracks    0 6 4

--- a/src/CEDViewer.cc
+++ b/src/CEDViewer.cc
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <algorithm>
+#include <set>
 
 #include <marlin/Global.h>
 #include <gear/GEAR.h>
@@ -340,6 +341,8 @@ void CEDViewer::processEvent( LCEvent * evt ) {
         }
     }
     
+    std::set< std::string > colsInEvent ;
+
     unsigned nCols = drawParameters.size() ;
     for(unsigned np=0 ; np < nCols ; ++np){
         
@@ -351,7 +354,9 @@ void CEDViewer::processEvent( LCEvent * evt ) {
         LCCollection* col = 0 ;
         try{
             
-            col = evt->getCollection( colName ) ;
+          col = evt->getCollection( colName ) ;
+
+          colsInEvent.insert( colName ) ;
             
         }catch(DataNotAvailableException &e){
             
@@ -957,9 +962,8 @@ void CEDViewer::processEvent( LCEvent * evt ) {
         
     } // while
     
-    streamlog_out( MESSAGE ) << " ++++++++ collections shown on layer [ evt: " << evt->getEventNumber() 
-    <<  " run: " << evt->getRunNumber() << " ] :   +++++++++++++ " << std::endl ;
-    
+    streamlog_out( MESSAGE ) << " ++++++++ collections shown on layers:  +++++++++++++ " << std::endl ;
+
     for(unsigned np=0 ; np < nCols ; ++np){
         
         const std::string & colName = drawParameters[np].ColName ;
@@ -967,12 +971,27 @@ void CEDViewer::processEvent( LCEvent * evt ) {
         //     int marker = drawParameters[np].Marker ;
         int layer =  drawParameters[np].Layer ;
         
-        streamlog_out( MESSAGE )  << "    +++++  " << colName <<  "\t  on layer: " << layer << std::endl ;
+        if( colsInEvent.find( colName ) != colsInEvent.end() ) {
+          streamlog_out( MESSAGE )  << "    +++++  " << colName <<  "\t  on layer: " << layer << std::endl ;
+        }
     }
+    streamlog_out( MESSAGE ) << std::endl
+                             <<  " [ evt: " << evt->getEventNumber()
+                             <<  "   run: " << evt->getRunNumber() << " ] " << std::endl ;
+
     streamlog_out( MESSAGE ) << " ++++++++ use shift-[LN] for LN>10  +++++++++++++ " << std::endl ;
     
     
-    
+
+
+    // print run and event number in layer description 43 and 44
+    // displayed with keybord shortcuts
+    // std::stringstream sr,se ;
+    // sr << "run: " << evt->getRunNumber() ;
+    // se << "evt: " << evt->getEventNumber() ;
+    // MarlinCED::set_layer_description( sr.str().c_str(), 43 );
+    // MarlinCED::set_layer_description( se.str().c_str(), 44 );
+
     //++++++++++++++++++++++++++++++++++++
 
 

--- a/src/DDCEDViewer.cc
+++ b/src/DDCEDViewer.cc
@@ -444,8 +444,7 @@ DDCEDPickingHandler &pHandler=DDCEDPickingHandler::getInstance();
         }    
     }
 
-    streamlog_out( MESSAGE ) << " ++++++++ collections shown on layer [ evt: " << evt->getEventNumber() 
-    <<  " run: " << evt->getRunNumber() << " ] :   +++++++++++++ " << std::endl ;
+    streamlog_out( MESSAGE ) << " ++++++++ collections shown on layers:  +++++++++++++ " << std::endl ;
     
     for(unsigned np=0 ; np < nCols ; ++np){
         
@@ -458,6 +457,11 @@ DDCEDPickingHandler &pHandler=DDCEDPickingHandler::getInstance();
           streamlog_out( MESSAGE )  << "    +++++  " << colName <<  "\t  on layer: " << layer << std::endl ;
         }
     }
+
+    streamlog_out( MESSAGE ) << std::endl
+                             <<  " [ evt: " << evt->getEventNumber()
+                             <<  "   run: " << evt->getRunNumber() << " ] " << std::endl ;
+
     streamlog_out( MESSAGE ) << " ++++++++ use shift-[LN] for LN>10  +++++++++++++ " << std::endl ;
     
 


### PR DESCRIPTION

BEGINRELEASENOTES
- improved CEDViewer/DDCEDViewer (also used by ced2go)
      - print run and event number at end of event
      - print only shown collections 
      - added new collections ( mostly calo hits) from ILD mass production
 
ENDRELEASENOTES