### PR TITLE
Add possibility to color reconstructed particles by energy

### DIFF
--- a/ced2go/ced2go-template-DD4.xml
+++ b/ced2go/ced2go-template-DD4.xml
@@ -79,6 +79,10 @@
   <parameter name="ColorByEnergyBrightness" type="double">1.0</parameter>
   <!-- Automatically adjust event by event the blue to min energy and red to max energy of event -->
   <parameter name="ColorByEnergyAutoColor" type="bool">false</parameter>
+  <!-- Scale line thickness of drawn helixes, usefull for image dumps -->
+  <parameter name="ScaleLineThickness" type="double">1</parameter>
+  <!-- Scale marker size of cluster markers, usefull for image dumps -->
+  <parameter name="ScaleMarkerSize" type="double">1</parameter>
   <!--Max R (mm) Extent for drawing Helix if UseTPCForLimitsOfHelix false-->
   <parameter name="HelixMaxR" type="float">2000 </parameter>
   <!--Max Z (mm) Extent for drawing Helix if UseTPCForLimitsOfHelix false-->

--- a/ced2go/ced2go-template-DD4.xml
+++ b/ced2go/ced2go-template-DD4.xml
@@ -67,6 +67,18 @@
   <parameter name="DrawHelixForPFOs" type="int">0 </parameter>
   <!--draw a helix for Track objects: -1: none, 0: default, 1: atIP, 2: atFirstHit, 3: atLastHit, 4: atCalorimeter-->
   <parameter name="DrawHelixForTrack" type="int">0 </parameter>
+  <!-- Color recunstructed particle by energy -->
+  <parameter name="ColorByEnergy" type="bool">false</parameter>
+  <!-- Minimal value for energy which will be represented as blue -->
+  <parameter name="ColorByEnergyMin" type="double">0.0</parameter>
+  <!-- Maximal value for energy which will be represented as red -->
+  <parameter name="ColorByEnergyMax" type="double">35.0</parameter>
+  <!-- Hue value that will be used to determine the pallete -->
+  <parameter name="ColorByEnergySaturation" type="double">1.0</parameter>
+  <!-- Brigtness value that will be used to determine the pallete -->
+  <parameter name="ColorByEnergyBrightness" type="double">1.0</parameter>
+  <!-- Automatically adjust event by event the blue to min energy and red to max energy of event -->
+  <parameter name="ColorByEnergyAutoColor" type="bool">false</parameter>
   <!--Max R (mm) Extent for drawing Helix if UseTPCForLimitsOfHelix false-->
   <parameter name="HelixMaxR" type="float">2000 </parameter>
   <!--Max Z (mm) Extent for drawing Helix if UseTPCForLimitsOfHelix false-->

--- a/ced2go/ced2go-template.xml
+++ b/ced2go/ced2go-template.xml
@@ -50,6 +50,22 @@ $LCIOInputFiles$
   <parameter name="DrawDetectorID" type="int">0 </parameter>
   <!--draw a helix for PFO objects (usefull for Si tracker): 0: disabled, 1: enabled-->
   <parameter name="DrawHelixForPFOs" type="int">0 </parameter>
+  <!-- Color recunstructed particle by energy -->
+  <parameter name="ColorByEnergy" type="bool">false</parameter>
+  <!-- Minimal value for energy which will be represented as blue -->
+  <parameter name="ColorByEnergyMin" type="double">0.0</parameter>
+  <!-- Maximal value for energy which will be represented as red -->
+  <parameter name="ColorByEnergyMax" type="double">35.0</parameter>
+  <!-- Hue value that will be used to determine the pallete -->
+  <parameter name="ColorByEnergySaturation" type="double">1.0</parameter>
+  <!-- Brigtness value that will be used to determine the pallete -->
+  <parameter name="ColorByEnergyBrightness" type="double">1.0</parameter>
+  <!-- Automatically adjust event by event the blue to min energy and red to max energy of event -->
+  <parameter name="ColorByEnergyAutoColor" type="bool">false</parameter>
+  <!-- Scale line thickness of drawn helixes, usefull for image dumps -->
+  <parameter name="ScaleLineThickness" type="double">1</parameter>
+  <!-- Scale marker size of cluster markers, usefull for image dumps -->
+  <parameter name="ScaleMarkerSize" type="double">1</parameter>
   <!--draw a helix for Track objects: -1: none, 0: default, 1: atIP, 2: atFirstHit, 3: atLastHit, 4: atCalorimeter-->
   <parameter name="DrawHelixForTrack" type="int">0 </parameter>
   <!--Max R (mm) Extent for drawing Helix if UseTPCForLimitsOfHelix false-->

--- a/include/CEDViewer.h
+++ b/include/CEDViewer.h
@@ -74,26 +74,34 @@ class CEDViewer : public Processor {
   
   /** Input collection name.
    */
-  StringVec _drawCollections ;
-  StringVec _drawCollectionsLayer ;
+  StringVec _drawCollections {};
+  StringVec _drawCollectionsLayer {};
 
-  bool      _usingParticleGun ;
-  int       _drawHelixForTracks ;
-  int       _drawDetectorID  ;
-  int       _colorScheme ;
-  float     _mcpECut ;
+  bool      _usingParticleGun            = false ;
+  int       _drawHelixForTracks          = 0 ;
+  bool      _colorEnergy                 = false ;
+  double    _colorEnergyMin              = 0.0 ;
+  double    _colorEnergyMax              = 35.0 ;
+  double    _colorEnergySaturation       = 0.8 ;
+  double    _colorEnergyValue            = 0.8 ;
+  bool      _colorEnergyAuto             = false ;
+  double    _scaleLineThickness          = 1 ;
+  double    _scaleMarkerSize             = 1 ;
+  int       _drawDetectorID              = 0  ;
+  int       _colorScheme                 = 10;
+  float     _mcpECut                     = 0.001;
 
-  float     _helix_max_r;
-  float     _helix_max_z;
-  bool      _useTPCForLimitsOfHelix;
-  int       _waitForKeyboard ;
-  int       _drawHelixForPFOs;
-  int       _useColorForHelixTracks ;
-  IntVec    _colors ;
+  float     _helix_max_r                 = 2000 ;
+  float     _helix_max_z                 = 2500 ;
+  bool      _useTPCForLimitsOfHelix      = false ;
+  int       _waitForKeyboard             = 1 ;
+  int       _drawHelixForPFOs            = 0 ;
+  int       _useColorForHelixTracks      = 0;
+  IntVec    _colors {};
 
 
-  int _nRun ;
-  int _nEvt ;
+  int _nRun = 0 ;
+  int _nEvt = 0 ;
 } ;
 
 #endif

--- a/include/ColorMap.h
+++ b/include/ColorMap.h
@@ -12,6 +12,20 @@
 
 typedef void (*colorMapFunc)(unsigned int*,float,float,float);
 
+typedef struct RgbColor
+{
+    double r;
+    double g;
+    double b;
+} RgbColor;
+
+typedef struct HsvColor
+{
+    double h;
+    double s;
+    double v;
+} HsvColor;
+
 class ColorMap{
  public:
   static void colorMap(unsigned int *rgb,float value,float min,float max);
@@ -24,6 +38,8 @@ class ColorMap{
   static void blueColorMap(unsigned int *rgb,float value,float min,float max);
   static colorMapFunc selectColorMap(int cmp);
   static int RGB2HEX(int red, int green, int blue);
+  static RgbColor HsvToRgb(HsvColor in);
+  static unsigned long NumberToTemperature(double value, double min, double max, double s, double v);
 };
 
 #endif

--- a/include/DDCEDViewer.h
+++ b/include/DDCEDViewer.h
@@ -113,32 +113,38 @@ class DDCEDViewer : public Processor {
   static const int Light       =   11 ;
   static const int Classic     =   12 ;
   
-  StringVec _drawCollections ;
-  StringVec _drawCollectionsLayer ;
-  std::vector< DrawParameters > drawParameters ;
+  StringVec _drawCollections{} ;
+  StringVec _drawCollectionsLayer{} ;
+  std::vector< DrawParameters > drawParameters{} ;
 
   //general options
-  int _nRun ;
-  int _nEvt ;
+  int _nRun = 0 ;
+  int _nEvt = 0;
   //lcio options
-  bool      _usingParticleGun ;
-  int       _drawHelixForTracks ;
-  int       _colorScheme ;
-  float     _mcpECut ;
-  float     _helix_max_r;
-  float     _helix_max_z;
-  bool      _useTrackerForLimitsOfHelix;
-  int       _waitForKeyboard ;
-  int       _drawHelixForPFOs;
-  int       _useColorForHelixTracks ;
-  int       _drawEllipsoidForPFOClusters ;
-  IntVec    _colors ;
+  bool      _usingParticleGun            = false ;
+  int       _drawHelixForTracks          = 0 ;
+  int       _colorScheme                 = 10 ;
+  bool      _colorEnergy                 = false ;
+  double    _colorEnergyMin              = 0.0 ;
+  double    _colorEnergyMax              = 35.0 ;
+  double    _colorEnergySaturation       = 0.8 ;
+  double    _colorEnergyValue            = 0.8 ;
+  bool      _colorEnergyAuto             = false ;
+  float     _mcpECut                     = 0.001 ;
+  float     _helix_max_r                 = 2000 ;
+  float     _helix_max_z                 = 2500 ;
+  bool      _useTrackerForLimitsOfHelix  = true ;
+  int       _waitForKeyboard             = 1 ;
+  int       _drawHelixForPFOs            = 0 ;
+  int       _useColorForHelixTracks      = 0 ;
+  int       _drawEllipsoidForPFOClusters = 0 ;
+  IntVec    _colors{} ;
 
   //detector options
-  bool _begin;
-  StringVec _detailled;
-  StringVec _jets;
-  bool _surfaces;
+  bool _begin          = false;
+  StringVec _detailled{};
+  StringVec _jets{};
+  bool _surfaces       = false;
 } ;
 
 

--- a/include/DDCEDViewer.h
+++ b/include/DDCEDViewer.h
@@ -130,6 +130,8 @@ class DDCEDViewer : public Processor {
   double    _colorEnergySaturation       = 0.8 ;
   double    _colorEnergyValue            = 0.8 ;
   bool      _colorEnergyAuto             = false ;
+  double    _scaleLineThickness          = 1 ;
+  double    _scaleMarkerSize             = 1 ;
   float     _mcpECut                     = 0.001 ;
   float     _helix_max_r                 = 2000 ;
   float     _helix_max_z                 = 2500 ;

--- a/src/ColorMap.cc
+++ b/src/ColorMap.cc
@@ -205,3 +205,78 @@ colorMapFunc ColorMap::selectColorMap(int cmp)
     return colorMap;
   };
 }
+// taken from https://stackoverflow.com/questions/3018313/algorithm-to-convert-rgb-to-hsv-and-hsv-to-rgb-in-range-0-255-for-both#comment66194776_14733008
+RgbColor ColorMap::HsvToRgb(HsvColor in){
+    double      hh, p, q, t, ff;
+    long        i;
+    RgbColor    out;
+
+    if(in.s <= 0.0) {       // < is bogus, just shuts up warnings
+        out.r = in.v;
+        out.g = in.v;
+        out.b = in.v;
+        return out;
+    }
+    hh = in.h;
+    if(hh >= 360.0) hh = 0.0;
+    hh /= 60.0;
+    i = (long)hh;
+    ff = hh - i;
+    p = in.v * (1.0 - in.s);
+    q = in.v * (1.0 - (in.s * ff));
+    t = in.v * (1.0 - (in.s * (1.0 - ff)));
+
+    switch(i) {
+    case 0:
+        out.r = in.v;
+        out.g = t;
+        out.b = p;
+        break;
+    case 1:
+        out.r = q;
+        out.g = in.v;
+        out.b = p;
+        break;
+    case 2:
+        out.r = p;
+        out.g = in.v;
+        out.b = t;
+        break;
+
+    case 3:
+        out.r = p;
+        out.g = q;
+        out.b = in.v;
+        break;
+    case 4:
+        out.r = t;
+        out.g = p;
+        out.b = in.v;
+        break;
+    case 5:
+    default:
+        out.r = in.v;
+        out.g = p;
+        out.b = q;
+        break;
+    }
+    return out;
+}
+
+// Convert a number between min in max to a color between blue(min) and red(max)
+unsigned long ColorMap::NumberToTemperature(double value, double min, double max, double s, double v){
+    if( value > max ){
+        value = max;
+    }else if ( value < min ){
+        value = min;
+    }
+
+    HsvColor hsv;
+    hsv.h = 270 - ( value - min ) / ( max - min ) * 270;
+    hsv.s=s;
+    hsv.v=v;
+
+    RgbColor rgb = ColorMap::HsvToRgb(hsv);
+
+    return ColorMap::RGB2HEX((int)(rgb.r*255),(int)(rgb.g*255),(int)(rgb.b*255));
+}

--- a/src/DDCEDViewer.cc
+++ b/src/DDCEDViewer.cc
@@ -116,6 +116,15 @@ DDCEDViewer::DDCEDViewer() : Processor("DDCEDViewer") {
                                _colorEnergyAuto,
                                bool(false) ) ;
 
+    registerProcessorParameter( "ScaleLineThickness" ,
+                               "Scale the line thickness of drawn helixes",
+                               _scaleLineThickness,
+                               double(1.0) ) ;
+
+    registerProcessorParameter( "ScaleMarkerSize" ,
+                               "Scale the size of the markes",
+                               _scaleMarkerSize,
+                               double(1.0) ) ;
     
     registerProcessorParameter( "MCParticleEnergyCut" ,
                                "minimum energy of MCParticles to be drawn",
@@ -522,12 +531,12 @@ void DDCEDViewer::drawCluster(dd4hep::Detector& /*theDetector*/, int& layer, uns
             ced_hit_ID( (*it)->getPosition()[0],
                        (*it)->getPosition()[1],
                        (*it)->getPosition()[2],
-                       marker, layer, size , color, clu->id() ) ;
+                       marker, layer, size*_scaleMarkerSize , color, clu->id() ) ;
         } 
         float x = clu->getPosition()[0] ;
         float y = clu->getPosition()[1] ;
         float z = clu->getPosition()[2] ;
-        ced_hit_ID( x,y,z, marker, layer , size*3 , color, clu->id() ) ;
+        ced_hit_ID( x,y,z, marker, layer , size*3*_scaleMarkerSize , color, clu->id() ) ;
         LCVector3D v(x,y,z) ;
         LCVector3D d(1.,1.,1.) ;
         float length = 100 + 500 * ( clu->getEnergy() - emin )  / ( emax - emin )  ;
@@ -567,7 +576,7 @@ void DDCEDViewer::drawTrack(dd4hep::Detector& theDetector, int& layer, unsigned&
             ced_hit_ID( (*it)->getPosition()[0],
                        (*it)->getPosition()[1],
                        (*it)->getPosition()[2],
-                       marker, layer , size , color , trk->id() ) ;
+                       marker, layer , size*_scaleMarkerSize , color , trk->id() ) ;
         } // hits
         const TrackState* ts = 0 ;
         switch( _drawHelixForTracks ){
@@ -591,7 +600,7 @@ void DDCEDViewer::drawTrack(dd4hep::Detector& theDetector, int& layer, unsigned&
                 ced_hit_ID( ts->getReferencePoint()[0],
                            ts->getReferencePoint()[1],
                            ts->getReferencePoint()[2],
-                           1 , layer , size*10 , color , trk->id() ) ;
+                           1 , layer , size*10*_scaleMarkerSize , color , trk->id() ) ;
                 break ;
         }
         if( ts !=0 ){
@@ -626,7 +635,7 @@ void DDCEDViewer::drawTrack(dd4hep::Detector& theDetector, int& layer, unsigned&
                 const int ml = marker | ( layer << CED_LAYER_SHIFT ) ;
                 int helixColor = ( _useColorForHelixTracks ? color : 0xdddddd ) ;
                 DDMarlinCED::drawHelix( bField , charge, xs, ys, zs ,
-                                     px, py, pz, ml ,  2 , helixColor  ,
+                                     px, py, pz, ml ,  2*_scaleLineThickness , helixColor  ,
                                      0.0, _helix_max_r,
                                      _helix_max_z, trk->id() ) ;
             }
@@ -683,7 +692,7 @@ void DDCEDViewer::drawMCParticle(dd4hep::Detector& theDetector, int& layer, unsi
                     _hmz = _helix_max_z;
             }
             DDMarlinCED::drawHelix( bField , charge, x, y, z,
-                                 px, py, pz, ml , size , 0x7af774  ,
+                                 px, py, pz, ml , size*_scaleLineThickness , 0x7af774  ,
                                  0.0,  _hmr ,
                                  _hmz, mcp->id() ) ; 
         } else { // neutral
@@ -732,7 +741,7 @@ void DDCEDViewer::drawSIMTrackerHit(int& layer, unsigned& np, std::string colNam
         ced_hit_ID( h->getPosition()[0],
                    h->getPosition()[1],
                    h->getPosition()[2],
-                   marker,layer, size , color, id ) ;
+                   marker,layer, size*_scaleMarkerSize , color, id ) ;
         
     }
 }
@@ -756,7 +765,7 @@ void DDCEDViewer::drawSIMCalorimeterHit(int& layer, unsigned& np, std::string co
         ced_hit_ID( h->getPosition()[0],
                    h->getPosition()[1],
                    h->getPosition()[2],
-                   marker,layer, size , color, id ) ;
+                   marker,layer, size*_scaleMarkerSize , color, id ) ;
         
     }
 }
@@ -778,7 +787,7 @@ void DDCEDViewer::drawTrackerHit(int& layer, unsigned& np, std::string colName, 
         for( unsigned i=0,N=hits.size() ; i<N ; ++i){
             TrackerHitPlane* h = hits[i] ;
             TVector3 p(h->getPosition()[0] ,  h->getPosition()[1] ,  h->getPosition()[2]);
-            ced_hit_ID( p.X(), p.Y(), p.Z(), marker, layer , size , color, h->id() );
+            ced_hit_ID( p.X(), p.Y(), p.Z(), marker, layer , size*_scaleMarkerSize , color, h->id() );
             // draw an additional line for strip hits 
             if(  BitSet32( h->getType() )[ ILDTrkHitTypeBit::ONE_DIMENSIONAL ] ) {
                 double strip_half_length = 50. ; //FIXME: need to get the proper strip length (from the surface !?) 
@@ -877,7 +886,7 @@ void DDCEDViewer::drawReconstructedParticle(dd4hep::Detector& theDetector, int& 
               float x = hit->getPosition()[0];
               float y = hit->getPosition()[1];
               float z = hit->getPosition()[2];
-              ced_hit_ID(x,y,z,marker, layer ,size,color,part->id()); 
+              ced_hit_ID(x,y,z,marker, layer ,size*_scaleMarkerSize,color,part->id());
             }
           }
 
@@ -994,7 +1003,7 @@ void DDCEDViewer::drawReconstructedParticle(dd4hep::Detector& theDetector, int& 
                         float x = (float)hit->getPosition()[0];
                         float y = (float)hit->getPosition()[1];
                         float z = (float)hit->getPosition()[2];
-                        ced_hit_ID(x,y,z,marker, layer,size,color,part->id());
+                        ced_hit_ID(x,y,z,marker, layer,size*_scaleMarkerSize,color,part->id());
                     }
                 }
                 if((nHits==0 || _drawHelixForPFOs==1) && std::fabs(part->getCharge())>0.001){
@@ -1022,7 +1031,7 @@ void DDCEDViewer::drawReconstructedParticle(dd4hep::Detector& theDetector, int& 
                         double Zs = ts->getReferencePoint()[2] +  ts->getZ0() ;
                         int helixColor = ( _useColorForHelixTracks ? color : 0xdddddd ) ;
                         //helix
-                        DDMarlinCED::drawHelix(bField, charge, Xs, Ys, Zs, Px, Py, Pz, marker|(layer<<CED_LAYER_SHIFT), size/2,
+                        DDMarlinCED::drawHelix(bField, charge, Xs, Ys, Zs, Px, Py, Pz, marker|(layer<<CED_LAYER_SHIFT), size/2*_scaleLineThickness,
                                              helixColor, 0.0, _helix_max_r, _helix_max_z, part->id() ); //hauke: add id
                     }
                 }


### PR DESCRIPTION
BEGINRELEASENOTES
- DDCEDViewer
  - Add option to color reconstructed particles by energy
    - the color range is from lowest blue to highest red, with possibility of the user to change brightens and saturation of the color pallet.
    - the color range can be fixed from a minimal energy to a maximal for all events or auto adopted event by event to span from min to max energy of a given/current event
  - Add option for scaling line thickness of helices and marker size, this is needed for good image dumps, since the displayed sizes differ from the ones in the dumped image

ENDRELEASENOTES