### PR TITLE
Fix for color range and particle energy

### DIFF
--- a/src/CEDViewer.cc
+++ b/src/CEDViewer.cc
@@ -855,19 +855,13 @@ void CEDViewer::processEvent( LCEvent * evt ) {
             MarlinCED::add_layer_description(colName, layer);
             
             int nelem = col->getNumberOfElements();
-            //Determine the maximal and minimal cluster energy depositions in the event for color scaling (-->when drawing ellipsoids/cylinders).
-            double Emin = 99999.; double Emax = 0;
+            //Determine the maximal and minimal particle energy energy coloring
+            double pEmin = 99999.; double pEmax = 0;
             for (int ip(0); ip < nelem; ++ip) {
                 ReconstructedParticle * part = dynamic_cast<ReconstructedParticle*>(col->getElementAt(ip));
-                ClusterVec clusterVec = part->getClusters();
-                unsigned nClusters = (unsigned)clusterVec.size();
-                if (nClusters > 0 ) {
-                    for (unsigned int p=0; p<nClusters; p++) {
-                        double e = clusterVec[p]->getEnergy();
-                        Emin = fmin(Emin, e);
-                        Emax = fmax(Emax, e);
-                    }
-                }
+                float pene = part->getEnergy();
+                pEmin = fmin(pEmin, pene);
+                pEmax = fmax(pEmax, pene);
             }
             
             float TotEn = 0.0;
@@ -893,7 +887,7 @@ void CEDViewer::processEvent( LCEvent * evt ) {
 
                 if( _colorEnergy ){
                    if( _colorEnergyAuto ){
-                       color = ColorMap::NumberToTemperature(ene,Emin,Emax,_colorEnergySaturation,_colorEnergyValue);
+                       color = ColorMap::NumberToTemperature(ene,pEmin,pEmax,_colorEnergySaturation,_colorEnergyValue);
                    }else{
                        color = ColorMap::NumberToTemperature(ene,_colorEnergyMin,_colorEnergyMax,_colorEnergySaturation,_colorEnergyValue);
                    }

--- a/src/ColorMap.cc
+++ b/src/ColorMap.cc
@@ -272,7 +272,7 @@ unsigned long ColorMap::NumberToTemperature(double value, double min, double max
     }
 
     HsvColor hsv;
-    hsv.h = 270 - ( value - min ) / ( max - min ) * 270;
+    hsv.h = 240 - ( value - min ) / ( max - min ) * 240;
     hsv.s=s;
     hsv.v=v;
 

--- a/src/DDCEDViewer.cc
+++ b/src/DDCEDViewer.cc
@@ -828,9 +828,13 @@ void DDCEDViewer::drawReconstructedParticle(dd4hep::Detector& theDetector, int& 
     
     //Determine the maximal and minimal cluster energy depositions in the event for color scaling (-->when drawing ellipsoids/cylinders).
     double Emin = 99999.; double Emax = 0;
+    double pEmin = 99999.; double pEmax = 0;
     for (int ip(0); ip < nelem; ++ip) {
         ReconstructedParticle * part = dynamic_cast<ReconstructedParticle*>(col->getElementAt(ip));
         ClusterVec clusterVec = part->getClusters();
+        float pene = part->getEnergy();
+        pEmin = fmin(pEmin, pene);
+        pEmax = fmax(pEmax, pene);
         unsigned nClusters = (unsigned)clusterVec.size();
         if (nClusters > 0 ) {
             for (unsigned int p=0; p<nClusters; p++) {
@@ -857,7 +861,7 @@ void DDCEDViewer::drawReconstructedParticle(dd4hep::Detector& theDetector, int& 
         
         if( _colorEnergy ){
           if( _colorEnergyAuto ){
-            color = ColorMap::NumberToTemperature(ene,Emin,Emax,_colorEnergySaturation,_colorEnergyValue);
+            color = ColorMap::NumberToTemperature(ene,pEmin,pEmax,_colorEnergySaturation,_colorEnergyValue);
           }else{
             color = ColorMap::NumberToTemperature(ene,_colorEnergyMin,_colorEnergyMax,_colorEnergySaturation,_colorEnergyValue);
           }


### PR DESCRIPTION
small fix for #9 
Blue is in hue 240 degrees and not 270, subsequently the lowest energy particle was pink.
The cluster energy was used for determining the max and min energy of the event instead of the particle energy. 