### PR TITLE
Fix typo bug in the ced2go local host argument option

### DIFF
--- a/ced2go/ced2go
+++ b/ced2go/ced2go
@@ -125,7 +125,7 @@ for key in opts:
     if key[0]  == "-s":
         keys['$DrawSurfaces$'] = 'true' if (key[1] == "1") else 'false'
     if key[0]  == "-n":
-        keys['NoCED$'] = 'true' if ( key[1] == "1" ) else 'false'
+        keys['$NoCED$'] = 'true' if ( key[1] == "1" ) else 'false'
     if key[0] in ("-h", "--help"):
         help()
         sys.exit(0)


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix typo bug in the ced2go local host argument option
ENDRELEASENOTES

Launching event display on the local host with `ced2go` didn't work, because of the missing `$` while checking the command line argument `n`