### PR TITLE
Make sure that the environment is set according to the provided arguments

### DIFF
--- a/ced2go/ced2go
+++ b/ced2go/ced2go
@@ -19,13 +19,7 @@ from __future__ import print_function
 
 import sys
 import re
-if sys.version_info[0] > 2 or ( sys.version_info[0] == 2 and sys.version_info[1]>= 4):
-    import subprocess
-    old = 0
-else:
-    print ("Warning: Python Version < 2.4...")
-    old = 1
-    import popen2
+import subprocess
 import os
 import signal
 import time
@@ -182,10 +176,7 @@ else:  #find out the detector name used in the lcio file
             'LDC_GLD_01Sc':standartconfig+ '/mc2008/gear_LDC_GLD_01Sc.xml'
     }
 
-    if old:
-        detector=os.popen(extractDetector + " " + keys['$LCIOInputFiles$']).readline()
-    else:
-        detector= str(subprocess.Popen([extractDetector,keys['$LCIOInputFiles$']], stdout=subprocess.PIPE).communicate()[0])
+    detector= str(subprocess.Popen([extractDetector,keys['$LCIOInputFiles$']], stdout=subprocess.PIPE).communicate()[0])
 
     detector=detector.rstrip() #remove newline
 
@@ -238,28 +229,25 @@ if keys['$NoCED$'] == 'false':
 startced += [ Marlin, steeringFile ]
     
 #start ced and marlin
-if old:
-    os.system(" ".join(startced))
-else:
-    if keys['$NoCED$'] == 'false':
-        CEDobj    = subprocess.Popen(startced[0:3])
+if keys['$NoCED$'] == 'false':
+    CEDobj    = subprocess.Popen(startced[0:3])
             
-    MarlinCallArgs = [Marlin, steeringFile]
-    for marlinOpt in marlincommands:
-        MarlinCallArgs.append(marlinOpt)
-    Marlinobj = subprocess.Popen(MarlinCallArgs)
+MarlinCallArgs = [Marlin, steeringFile]
+for marlinOpt in marlincommands:
+    MarlinCallArgs.append(marlinOpt)
+Marlinobj = subprocess.Popen(MarlinCallArgs)
 
-    #terminate the both processes when one is closed
-    while True: 
-        if Marlinobj.poll() != None:
-            os.kill(CEDobj.pid,15)
+#terminate the both processes when one is closed
+while True:
+    if Marlinobj.poll() != None:
+        os.kill(CEDobj.pid,15)
+        break
+
+    if keys['$NoCED$'] == 'false':
+        if CEDobj.poll() != None:
+            os.kill(Marlinobj.pid,15)
             break
 
-        if keys['$NoCED$'] == 'false':
-            if CEDobj.poll() != None:
-                os.kill(Marlinobj.pid,15)
-                break
-
-        time.sleep(0.5) #sleep for 0.5 seconds
+    time.sleep(0.5) #sleep for 0.5 seconds
 
 print ("Done")

--- a/ced2go/ced2go
+++ b/ced2go/ced2go
@@ -225,6 +225,11 @@ if keys['$NoCED$'] == 'false':
         break
     os.environ['CED_PORT']=str(port)
     startced = [CED,"-geometry", "800x600","&","sleep 1;"]
+    # Make sure to pop the CED_HOST from the environment, because otherwise CED
+    # will try to connect to it. See https://github.com/iLCSoft/CEDViewer/issues/21
+    orig_ced_host = os.environ.pop('CED_HOST', None)
+    if orig_ced_host:
+        print('Unset CED_HOST env variable. Original value: {}'.format(orig_ced_host))
 
 startced += [ Marlin, steeringFile ]
     


### PR DESCRIPTION

BEGINRELEASENOTES
- Make sure that `ced2go` can be run without the `-n` argument even if `CED_HOST` is set. Fixes #21

ENDRELEASENOTES

@dudarboh I did some tests on my end. How hard would it be for you to run a test as well to see if this indeed fixes things.